### PR TITLE
Implement basic infrastructure

### DIFF
--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -1,8 +1,9 @@
 import Cocoa
 
 @NSApplicationMain
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, ApplicationControllerDelegate {
   var window: NSWindow?
+  let applicationController = ApplicationController()
 
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     loadInjection()
@@ -18,6 +19,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     window.setFrameAutosaveName(Bundle.main.bundleIdentifier!)
     window.makeKeyAndOrderFront(nil)
     self.window = window
+    applicationController.delegate = self
+    applicationController.load()
+  }
+
+  func applicationController(_ controller: ApplicationController,
+                             didLoadApplications applications: [Application]) {
+    Swift.print("Loaded \(applications.count) applications.")
   }
 }
 

--- a/Sources/Controllers/ApplicationController.swift
+++ b/Sources/Controllers/ApplicationController.swift
@@ -1,0 +1,92 @@
+import Cocoa
+
+protocol ApplicationControllerDelegate: class {
+  func applicationController(_ controller: ApplicationController, didLoadApplications applications: [Application])
+}
+
+class ApplicationController {
+  weak var delegate: ApplicationControllerDelegate?
+  @objc func injected() { load() }
+
+  private lazy var preferencesController = PreferencesController()
+  private lazy var infoPlistController = InfoPropertyListController()
+  private lazy var queue: DispatchQueue = { return DispatchQueue(label: String(describing: self),
+                                                                 qos: .userInitiated) }()
+
+  // MARK: - Public methods
+
+  func load() {
+    queue.async(execute: runAsync)
+  }
+
+  // MARK: - Private methods
+
+  private func runAsync() {
+    do {
+      let locations = try applicationDirectories()
+      var applications = [Application]()
+      for location in locations {
+        let urls = recursiveApplicationParse(at: location)
+        applications.append(contentsOf: loadApplications(urls))
+      }
+      DispatchQueue.main.async { [weak self] in
+        guard let strongSelf = self else { return }
+        strongSelf.delegate?.applicationController(strongSelf, didLoadApplications: applications)
+      }
+    } catch {}
+  }
+
+  private func applicationDirectories() throws -> [URL] {
+    let userDirectory = try FileManager.default.url(for: .applicationDirectory,
+                                                    in: .userDomainMask,
+                                                    appropriateFor: nil,
+                                                    create: false)
+    let applicationDirectory = try FileManager.default.url(for: .allApplicationsDirectory,
+                                                           in: .localDomainMask,
+                                                           appropriateFor: nil,
+                                                           create: false)
+
+    return [userDirectory, applicationDirectory]
+  }
+
+  private func recursiveApplicationParse(at url: URL) -> [URL] {
+    var result = [URL]()
+    var isDirectory: ObjCBool = true
+    guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+      let contents = try? FileManager.default.contentsOfDirectory(at: url,
+                                                                  includingPropertiesForKeys: nil,
+                                                                  options: .skipsHiddenFiles) else { return [] }
+    for file in contents {
+      var isDirectory: ObjCBool = true
+      let isFolder = FileManager.default.fileExists(atPath: file.path, isDirectory: &isDirectory)
+      if isFolder && file.pathExtension != "app" && url.path.contains("/Applications") {
+        result.append(contentsOf: recursiveApplicationParse(at: file))
+      } else {
+        result.append(file)
+      }
+    }
+
+    return result
+  }
+
+  private func loadApplications(_ urls: [URL]) -> [Application] {
+    var applications = [Application]()
+    for path in urls {
+      do {
+        let application = try loadApplication(at: path)
+        applications.append(application)
+      } catch {}
+    }
+    return applications
+  }
+
+  private func loadApplication(at path: URL) throws -> Application {
+    let infoPath = path.appendingPathComponent("Contents/Info.plist")
+    let propertyList = try infoPlistController.load(at: infoPath)
+    let preferences = try preferencesController.load(propertyList)
+    let application = Application(path: path,
+                                  propertyList: propertyList,
+                                  preferences: preferences)
+    return application
+  }
+}

--- a/Sources/Controllers/InfoPropertyListController.swift
+++ b/Sources/Controllers/InfoPropertyListController.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum InfoPropertyListError: Error {
+  case fileNotFound
+  case unableToParseContents
+  case unableToResolveBundleIdentifier
+}
+
+class InfoPropertyListController {
+  func load(at url: URL) throws -> InfoPropertyList {
+    let path = url.path
+    let fileExists = FileManager.default.fileExists(atPath: path)
+
+    if !fileExists { throw InfoPropertyListError.fileNotFound }
+
+    guard let contents = NSDictionary.init(contentsOfFile: path) else {
+      throw InfoPropertyListError.unableToParseContents
+    }
+
+    guard let bundleIdentifier = contents.value(forPropertyListKey: .bundleIdentifier) else {
+      throw InfoPropertyListError.unableToResolveBundleIdentifier
+    }
+
+    let defaultsDomain = contents.value(forPropertyListKey: .defaultsDomain)
+
+    return InfoPropertyList(bundleIdentifier: bundleIdentifier,
+                            defaultsDomain: defaultsDomain,
+                            path: path)
+  }
+}
+
+fileprivate extension NSDictionary {
+  func value(forPropertyListKey key: InfoPropertyListKey) -> String? {
+    return value(forKey: key.rawValue) as? String
+  }
+}

--- a/Sources/Controllers/PreferencesController.swift
+++ b/Sources/Controllers/PreferencesController.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum PreferencesControllerError: Error {
+  case unableToFindPreferenceFile
+}
+
+class PreferencesController {
+  func load(_ infoPlist: InfoPropertyList) throws -> Preferences {
+    let libraryDirectory = try FileManager.default.url(for: .libraryDirectory,
+                                                       in: .userDomainMask,
+                                                       appropriateFor: nil,
+                                                       create: false)
+
+    let suffix = "Preferences/\(infoPlist.bundleIdentifier).plist"
+    let applicationPreference = libraryDirectory.appendingPathComponent(suffix)
+    let containerPreferenceUrl = libraryDirectory.appendingPathComponent("Containers/\(infoPlist.bundleIdentifier)/Data/Library/\(suffix)")
+
+    var defaultsDomainContainerUrl: URL?
+    var defaultsDomainLibraryUrl: URL?
+
+    if let defaultsDomain = infoPlist.defaultsDomain {
+      let suffix = "Preferences/\(defaultsDomain).plist"
+      defaultsDomainContainerUrl = libraryDirectory.appendingPathComponent("Containers/\(infoPlist.bundleIdentifier)/Data/Library/\(suffix)")
+      defaultsDomainLibraryUrl = libraryDirectory.appendingPathComponent(suffix)
+    }
+
+    if let defaultsDomainUrl = defaultsDomainContainerUrl,
+      FileManager.default.fileExists(atPath: defaultsDomainUrl.path) {
+      return Preferences(path: defaultsDomainUrl)
+    } else if let defaultsDomainUrl = defaultsDomainLibraryUrl,
+      FileManager.default.fileExists(atPath: defaultsDomainUrl.path) {
+      return Preferences(path: defaultsDomainUrl)
+    } else if FileManager.default.fileExists(atPath: containerPreferenceUrl.path) {
+      return Preferences(path: containerPreferenceUrl)
+    } else if FileManager.default.fileExists(atPath: applicationPreference.path) {
+      return Preferences(path: applicationPreference)
+    }
+
+    throw PreferencesControllerError.unableToFindPreferenceFile
+  }
+}

--- a/Sources/Models/Application.swift
+++ b/Sources/Models/Application.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Application {
+  let path: URL
+  let propertyList: InfoPropertyList
+  let preferences: Preferences
+}

--- a/Sources/Models/InfoPropertyList.swift
+++ b/Sources/Models/InfoPropertyList.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum InfoPropertyListKey: String {
+  case bundleName = "CFBundleName"
+  case executableName = "CFBundleExecutable"
+  case iconFile = "CFBundleIconFile"
+  case bundleIdentifier = "CFBundleIdentifier"
+  case defaultsDomain = "SUDefaultsDomain"
+}
+
+struct InfoPropertyList {
+  let bundleIdentifier: String
+  let defaultsDomain: String?
+  let path: String
+}

--- a/Sources/Models/Preferences.swift
+++ b/Sources/Models/Preferences.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct Preferences {
+  let path: URL
+}

--- a/Syncalicious.xcodeproj/project.pbxproj
+++ b/Syncalicious.xcodeproj/project.pbxproj
@@ -7,12 +7,24 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD7D960C2252849100C93211 /* ApplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D960B2252849100C93211 /* ApplicationController.swift */; };
+		BD7D960E2252888000C93211 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D960D2252888000C93211 /* Application.swift */; };
+		BD7D961322528ADB00C93211 /* InfoPropertyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D961222528ADB00C93211 /* InfoPropertyList.swift */; };
+		BD7D961522528B8700C93211 /* InfoPropertyListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D961422528B8700C93211 /* InfoPropertyListController.swift */; };
+		BD7D9617225290C800C93211 /* PreferencesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D9616225290C800C93211 /* PreferencesController.swift */; };
+		BD7D96192252912100C93211 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D96182252912100C93211 /* Preferences.swift */; };
 		BD9313872251703400D116E4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9313862251703400D116E4 /* AppDelegate.swift */; };
 		BD9313892251703600D116E4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD9313882251703600D116E4 /* Assets.xcassets */; };
 		BD93138C2251703700D116E4 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD93138A2251703700D116E4 /* MainMenu.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BD7D960B2252849100C93211 /* ApplicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationController.swift; sourceTree = "<group>"; };
+		BD7D960D2252888000C93211 /* Application.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
+		BD7D961222528ADB00C93211 /* InfoPropertyList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPropertyList.swift; sourceTree = "<group>"; };
+		BD7D961422528B8700C93211 /* InfoPropertyListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPropertyListController.swift; sourceTree = "<group>"; };
+		BD7D9616225290C800C93211 /* PreferencesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesController.swift; sourceTree = "<group>"; };
+		BD7D96182252912100C93211 /* Preferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		BD9313832251703400D116E4 /* Syncalicious.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Syncalicious.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9313862251703400D116E4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BD9313882251703600D116E4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -43,6 +55,34 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		BD7D960F225288B700C93211 /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				BD9313862251703400D116E4 /* AppDelegate.swift */,
+			);
+			path = Application;
+			sourceTree = "<group>";
+		};
+		BD7D9610225288BD00C93211 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				BD7D960D2252888000C93211 /* Application.swift */,
+				BD7D961222528ADB00C93211 /* InfoPropertyList.swift */,
+				BD7D96182252912100C93211 /* Preferences.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		BD7D9611225288C100C93211 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				BD7D960B2252849100C93211 /* ApplicationController.swift */,
+				BD7D961422528B8700C93211 /* InfoPropertyListController.swift */,
+				BD7D9616225290C800C93211 /* PreferencesController.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
 		BD93137A2251703400D116E4 = {
 			isa = PBXGroup;
 			children = (
@@ -63,7 +103,9 @@
 		BD9313852251703400D116E4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				BD9313862251703400D116E4 /* AppDelegate.swift */,
+				BD7D960F225288B700C93211 /* Application */,
+				BD7D9611225288C100C93211 /* Controllers */,
+				BD7D9610225288BD00C93211 /* Models */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -143,6 +185,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD7D96192252912100C93211 /* Preferences.swift in Sources */,
+				BD7D9617225290C800C93211 /* PreferencesController.swift in Sources */,
+				BD7D961522528B8700C93211 /* InfoPropertyListController.swift in Sources */,
+				BD7D960E2252888000C93211 /* Application.swift in Sources */,
+				BD7D960C2252849100C93211 /* ApplicationController.swift in Sources */,
+				BD7D961322528ADB00C93211 /* InfoPropertyList.swift in Sources */,
 				BD9313872251703400D116E4 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Adds the basic infrastructure for resolving, parsing and processing applications from `/Applications` and `~/Applications`.

- It finds all applications located in the folders recursively
- Resolve information from the applications Info.plist and does an attempt to locate the preference file for the application
- It searches for preferences files in `~/Library/Preferences` and `~/Library/Container/~bundleidentifier/Data/Library/`
- If the application has set a defaults domain, then that will be used to resolve the correct plist file.