### PR TITLE
Refactor ApplicationController

### DIFF
--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -20,7 +20,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, ApplicationControllerDelegat
     window.makeKeyAndOrderFront(nil)
     self.window = window
     applicationController.delegate = self
-    applicationController.load()
+
+    do {
+      let locations = try applicationController.applicationDirectories()
+      applicationController.loadApplications(at: locations)
+    } catch {}
   }
 
   func applicationController(_ controller: ApplicationController,


### PR DESCRIPTION
Rename `load()` to `loadApplications(at:)`.
It makes the `ApplicationController` more testable and easier to extends.

`applicationDirectories()` has been move into the public API to make it easier to pass the directories as arguments to `loadApplications`.