### PR TITLE
Implements basic copy phase for backing up property lists

### DIFF
--- a/Sources/Application/DependencyContainer.swift
+++ b/Sources/Application/DependencyContainer.swift
@@ -2,17 +2,20 @@ import Foundation
 
 class DependencyContainer {
   let applicationController: ApplicationController
-  let backupController = BackupController()
+  let backupController: BackupController
   private let infoPlistController: InfoPropertyListController
+  private let machineController: MachineController
   private let preferencesController: PreferencesController
 
   init(applicationController: ApplicationController,
+       backupController: BackupController,
        infoPlistController: InfoPropertyListController,
+       machineController: MachineController,
        preferencesController: PreferencesController) {
     self.infoPlistController = InfoPropertyListController()
-    self.preferencesController = PreferencesController()
-    self.applicationController = ApplicationController(infoPlistController: infoPlistController,
-                                                       preferencesController: preferencesController)
-
+    self.machineController = machineController
+    self.preferencesController = preferencesController
+    self.backupController = backupController
+    self.applicationController = applicationController
   }
 }

--- a/Sources/Application/MainMenuController.swift
+++ b/Sources/Application/MainMenuController.swift
@@ -16,16 +16,28 @@ class MainMenuController: NSObject {
       alert.runModal()
       return
     }
-    dependencyContainer?.backupController.backup(to: backupDestination)
+    do {
+      try dependencyContainer?.backupController.initializeBackup(to: backupDestination)
+    } catch let error {
+      let alert = createAlert(error: error)
+      alert.runModal()
+    }
   }
 
   // MARK: - Private methods
 
-  private func createAlert(with text: String) -> NSAlert {
-    let alert = NSAlert()
+  private func createAlert(with text: String = "", error: Error? = nil) -> NSAlert {
+    let alert: NSAlert
+    if let error = error {
+      alert = NSAlert(error: error)
+    } else {
+      alert = NSAlert()
+      alert.messageText = text
+    }
+
     alert.alertStyle = .warning
     alert.addButton(withTitle: "Ok")
-    alert.messageText = text
+
     return alert
   }
 }

--- a/Sources/Controllers/MachineController.swift
+++ b/Sources/Controllers/MachineController.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum MachineError: Error {
+  case unableToResolveName
+  case unableToResolveLocalizedName
+}
+
+class MachineController {
+  let machine: Machine
+
+  public init(host: Host) throws {
+    guard let name = host.name else {
+      throw MachineError.unableToResolveName
+    }
+
+    guard let localizedName = host.localizedName else {
+      throw MachineError.unableToResolveLocalizedName
+    }
+
+    self.machine = Machine(name: name,
+                           localizedName: localizedName)
+  }
+
+  func machineBackupDestination(for destination: URL) -> URL {
+    return destination.appendingPathComponent(machine.name)
+  }
+}

--- a/Sources/Models/Machine.swift
+++ b/Sources/Models/Machine.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Machine {
+  let name: String
+  let localizedName: String
+}

--- a/Syncalicious.xcodeproj/project.pbxproj
+++ b/Syncalicious.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD4A692F2253BA6400F588AD /* Machine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A692E2253BA6400F588AD /* Machine.swift */; };
+		BD4A69312253BADE00F588AD /* MachineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A69302253BADE00F588AD /* MachineController.swift */; };
 		BD7D960C2252849100C93211 /* ApplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D960B2252849100C93211 /* ApplicationController.swift */; };
 		BD7D960E2252888000C93211 /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D960D2252888000C93211 /* Application.swift */; };
 		BD7D961322528ADB00C93211 /* InfoPropertyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D961222528ADB00C93211 /* InfoPropertyList.swift */; };
@@ -23,6 +25,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BD4A692E2253BA6400F588AD /* Machine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Machine.swift; sourceTree = "<group>"; };
+		BD4A69302253BADE00F588AD /* MachineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MachineController.swift; path = Sources/Controllers/MachineController.swift; sourceTree = SOURCE_ROOT; };
 		BD7D960B2252849100C93211 /* ApplicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationController.swift; sourceTree = "<group>"; };
 		BD7D960D2252888000C93211 /* Application.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
 		BD7D961222528ADB00C93211 /* InfoPropertyList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPropertyList.swift; sourceTree = "<group>"; };
@@ -79,6 +83,7 @@
 				BD7D960D2252888000C93211 /* Application.swift */,
 				BD7D961222528ADB00C93211 /* InfoPropertyList.swift */,
 				BD7D96182252912100C93211 /* Preferences.swift */,
+				BD4A692E2253BA6400F588AD /* Machine.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -88,6 +93,7 @@
 			children = (
 				BD7D960B2252849100C93211 /* ApplicationController.swift */,
 				BD7D961422528B8700C93211 /* InfoPropertyListController.swift */,
+				BD4A69302253BADE00F588AD /* MachineController.swift */,
 				BD7D9616225290C800C93211 /* PreferencesController.swift */,
 			);
 			path = Controllers;
@@ -218,6 +224,8 @@
 				BD7D9617225290C800C93211 /* PreferencesController.swift in Sources */,
 				BD7D961522528B8700C93211 /* InfoPropertyListController.swift in Sources */,
 				BD7D961C22532B6900C93211 /* BackupController.swift in Sources */,
+				BD4A692F2253BA6400F588AD /* Machine.swift in Sources */,
+				BD4A69312253BADE00F588AD /* MachineController.swift in Sources */,
 				BD7D960E2252888000C93211 /* Application.swift in Sources */,
 				BD7D962122533CE100C93211 /* DependencyContainer.swift in Sources */,
 				BD7D960C2252849100C93211 /* ApplicationController.swift in Sources */,


### PR DESCRIPTION
### Description

This PR adds the initial backup feature, which means it can copy property lists from the installed applications into a selected backup destination. It will create a folder inside using the hostname of the current machine to avoid any backup collisions if you have multiple machines that you want to back up.

### Screen grab

![Syncalicious](https://user-images.githubusercontent.com/57446/55420253-da640280-5576-11e9-9e67-1a4ef462bfca.gif)


