### PR TITLE
Feature initial test environment and add tests for ApplicationController

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ osx_image: xcode10.2
 language: objective-c
 
 script:
-  - set -o pipefail && xcodebuild -project Syncalicious.xcodeproj -scheme "Syncalicious" -sdk macosx clean test build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED="NO" | xcpretty
+  - set -o pipefail && xcodebuild -project Syncalicious.xcodeproj -scheme "Tests" -sdk macosx clean test build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED="NO" | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -63,10 +63,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, BackupControllerDelegate {
   }
 
   private func createDependencyContainer() throws -> DependencyContainer {
+    let libraryDirectory = try FileManager.default.url(for: .libraryDirectory,
+                                                       in: .userDomainMask,
+                                                       appropriateFor: nil,
+                                                       create: false)
     let machineController = try MachineController(host: Host.current())
     let infoPlistController = InfoPropertyListController()
-    let preferencesController = PreferencesController()
-    let applicationController = ApplicationController(infoPlistController: infoPlistController,
+    let preferencesController = PreferencesController(libraryDirectory: libraryDirectory)
+    let queue = DispatchQueue(label: String(describing: ApplicationController.self),
+                              qos: .userInitiated)
+    let applicationController = ApplicationController(queue: queue,
+                                                      infoPlistController: infoPlistController,
                                                       preferencesController: preferencesController)
     let backupController = BackupController(machineController: machineController)
     let dependencyContainer = DependencyContainer(applicationController: applicationController,

--- a/Sources/Application/MainMenuController.swift
+++ b/Sources/Application/MainMenuController.swift
@@ -11,7 +11,8 @@ class MainMenuController: NSObject {
 
   @IBAction func performBackup(_ sender: Any?) {
     guard let backupDestination = UserDefaults.standard.backupDestination else {
-      let message = NSLocalizedString("You need to pick a backup destination before you can make a backup.", comment: "")
+      let message = NSLocalizedString("You need to pick a backup destination before you can make a backup.",
+                                      comment: "")
       let alert = createAlert(with: message)
       alert.runModal()
       return

--- a/Sources/Controllers/PreferencesController.swift
+++ b/Sources/Controllers/PreferencesController.swift
@@ -5,12 +5,14 @@ enum PreferencesControllerError: Error {
 }
 
 class PreferencesController {
-  func load(_ infoPlist: InfoPropertyList) throws -> Preferences {
-    let libraryDirectory = try FileManager.default.url(for: .libraryDirectory,
-                                                       in: .userDomainMask,
-                                                       appropriateFor: nil,
-                                                       create: false)
 
+  let libraryDirectory: URL
+
+  init(libraryDirectory: URL) {
+    self.libraryDirectory = libraryDirectory
+  }
+
+  func load(_ infoPlist: InfoPropertyList) throws -> Preferences {
     let suffix = "Preferences/\(infoPlist.bundleIdentifier).plist"
     let applicationPreference = libraryDirectory.appendingPathComponent(suffix)
     let containerPreferenceUrl = libraryDirectory

--- a/Syncalicious.xcodeproj/project.pbxproj
+++ b/Syncalicious.xcodeproj/project.pbxproj
@@ -23,10 +23,11 @@
 		BD7D961F22532BA100C93211 /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D961E22532BA100C93211 /* UserDefaults+Extensions.swift */; };
 		BD7D962122533CE100C93211 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D962022533CE100C93211 /* DependencyContainer.swift */; };
 		BD7D962322533FF300C93211 /* MainMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7D962222533FF300C93211 /* MainMenuController.swift */; };
+		BD8EDD722255322A00110E56 /* TestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8EDD712255322A00110E56 /* TestController.swift */; };
 		BD9313872251703400D116E4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9313862251703400D116E4 /* AppDelegate.swift */; };
 		BD9313892251703600D116E4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD9313882251703600D116E4 /* Assets.xcassets */; };
 		BD93138C2251703700D116E4 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD93138A2251703700D116E4 /* MainMenu.xib */; };
-		BDCBB2AB22551372007C9404 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCBB2AA22551372007C9404 /* Tests.swift */; };
+		BDCBB2AB22551372007C9404 /* ApplicationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCBB2AA22551372007C9404 /* ApplicationControllerTests.swift */; };
 		BDCBB2C022551C5B007C9404 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BDCBB2C222551C5B007C9404 /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +60,7 @@
 		BD7D961E22532BA100C93211 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
 		BD7D962022533CE100C93211 /* DependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
 		BD7D962222533FF300C93211 /* MainMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuController.swift; sourceTree = "<group>"; };
+		BD8EDD712255322A00110E56 /* TestController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestController.swift; sourceTree = "<group>"; };
 		BD9313832251703400D116E4 /* Syncalicious.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Syncalicious.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD9313862251703400D116E4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BD9313882251703600D116E4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -66,7 +68,7 @@
 		BD93138D2251703700D116E4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BD93138E2251703700D116E4 /* Syncalicious.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Syncalicious.entitlements; sourceTree = "<group>"; };
 		BDCBB2A822551372007C9404 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		BDCBB2AA22551372007C9404 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		BDCBB2AA22551372007C9404 /* ApplicationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationControllerTests.swift; sourceTree = "<group>"; };
 		BDCBB2AC22551372007C9404 /* Info-Tests.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Tests.plist"; sourceTree = "<group>"; };
 		BDCBB2B622551725007C9404 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		BDCBB2C122551C5B007C9404 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -208,7 +210,8 @@
 		BDCBB2A922551372007C9404 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				BDCBB2AA22551372007C9404 /* Tests.swift */,
+				BDCBB2AA22551372007C9404 /* ApplicationControllerTests.swift */,
+				BD8EDD712255322A00110E56 /* TestController.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -365,7 +368,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BDCBB2AB22551372007C9404 /* Tests.swift in Sources */,
+				BDCBB2AB22551372007C9404 /* ApplicationControllerTests.swift in Sources */,
+				BD8EDD722255322A00110E56 /* TestController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Syncalicious.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Syncalicious.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -5,27 +5,12 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BD9313822251703400D116E4"
-               BuildableName = "Syncalicious.app"
-               BlueprintName = "Syncalicious"
-               ReferencedContainer = "container:Syncalicious.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
@@ -68,20 +53,10 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BD9313822251703400D116E4"
-            BuildableName = "Syncalicious.app"
-            BlueprintName = "Syncalicious"
-            ReferencedContainer = "container:Syncalicious.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "EnvironmentPath"
-            value = ""
+            value = "$(SRCROOT)/TestEnvironment"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -94,16 +69,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BD9313822251703400D116E4"
-            BuildableName = "Syncalicious.app"
-            BlueprintName = "Syncalicious"
-            ReferencedContainer = "container:Syncalicious.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Syncalicious.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Syncalicious.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -5,6 +5,22 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BD9313822251703400D116E4"
+               BuildableName = "Syncalicious.app"
+               BlueprintName = "Syncalicious"
+               ReferencedContainer = "container:Syncalicious.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -53,6 +69,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BD9313822251703400D116E4"
+            BuildableName = "Syncalicious.app"
+            BlueprintName = "Syncalicious"
+            ReferencedContainer = "container:Syncalicious.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "EnvironmentPath"
@@ -69,6 +94,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BD9313822251703400D116E4"
+            BuildableName = "Syncalicious.app"
+            BlueprintName = "Syncalicious"
+            ReferencedContainer = "container:Syncalicious.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/TestEnvironment/Applications/ContainerTestApp.app/Contents/Info.plist
+++ b/TestEnvironment/Applications/ContainerTestApp.app/Contents/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>ContainerTestApp</string>
+	<key>CFBundleExecutable</key>
+	<string>ContainerTestApp</string>
+	<key>CFBundleIconFile</key>
+	<string>app.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.zenangst.Syncalicious.ContainerTestApp</string>
+</dict>
+</plist>

--- a/TestEnvironment/Applications/ContainerTestAppSUDefaultsDomain.app/Contents/Info.plist
+++ b/TestEnvironment/Applications/ContainerTestAppSUDefaultsDomain.app/Contents/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>ContainerTestAppSUDefaultsDomain</string>
+	<key>CFBundleExecutable</key>
+	<string>ContainerTestAppSUDefaultsDomain</string>
+	<key>CFBundleIconFile</key>
+	<string>app.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain</string>
+	<key>SUDefaultsDomain</key>
+	<string>6C4433RDLX.group.com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain</string>
+</dict>
+</plist>

--- a/TestEnvironment/Applications/TestApp.app/Contents/Info.plist
+++ b/TestEnvironment/Applications/TestApp.app/Contents/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>TestApp</string>
+	<key>CFBundleExecutable</key>
+	<string>TestApp</string>
+	<key>CFBundleIconFile</key>
+	<string>app.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.zenangst.Syncalicious.TestApp</string>
+</dict>
+</plist>

--- a/TestEnvironment/Applications/TestAppWithSUDefaultsDomain.app/Contents/Info.plist
+++ b/TestEnvironment/Applications/TestAppWithSUDefaultsDomain.app/Contents/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>TestAppWithSUDefaultsDomain</string>
+	<key>CFBundleExecutable</key>
+	<string>TestAppWithSUDefaultsDomain</string>
+	<key>CFBundleIconFile</key>
+	<string>app.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.zenangst.Syncalicious.TestAppWithSUDefaultsDomain</string>
+	<key>SUDefaultsDomain</key>
+	<string>6C4433RDLX.group.com.zenangst.Syncalicious.TestAppWithSUDefaultsDomain</string>
+</dict>
+</plist>

--- a/TestEnvironment/Library/Containers/com.zenangst.Syncalicious.ContainerTestApp/Data/Library/Preferences/6C4433RDLX.group.com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain.plist
+++ b/TestEnvironment/Library/Containers/com.zenangst.Syncalicious.ContainerTestApp/Data/Library/Preferences/6C4433RDLX.group.com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SettingKey</key>
+	<string>SettingValue</string>
+</dict>
+</plist>

--- a/TestEnvironment/Library/Containers/com.zenangst.Syncalicious.ContainerTestApp/Data/Library/Preferences/com.zenangst.Syncalicious.ContainerTestApp.plist
+++ b/TestEnvironment/Library/Containers/com.zenangst.Syncalicious.ContainerTestApp/Data/Library/Preferences/com.zenangst.Syncalicious.ContainerTestApp.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SettingKey</key>
+	<string>SettingValue</string>
+</dict>
+</plist>

--- a/TestEnvironment/Library/Containers/com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain/Data/Library/Preferences/6C4433RDLX.group.com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain.plist
+++ b/TestEnvironment/Library/Containers/com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain/Data/Library/Preferences/6C4433RDLX.group.com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SettingKey</key>
+	<string>SettingValue</string>
+</dict>
+</plist>

--- a/TestEnvironment/Library/Preferences/6C4433RDLX.group.com.zenangst.Syncalicious.TestAppWithSUDefaultsDomain.plist
+++ b/TestEnvironment/Library/Preferences/6C4433RDLX.group.com.zenangst.Syncalicious.TestAppWithSUDefaultsDomain.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SettingKey</key>
+	<string>SettingValue</string>
+</dict>
+</plist>

--- a/TestEnvironment/Library/Preferences/com.zenangst.Syncalicious.TestApp.plist
+++ b/TestEnvironment/Library/Preferences/com.zenangst.Syncalicious.TestApp.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SettingKey</key>
+	<string>SettingValue</string>
+</dict>
+</plist>

--- a/Tests/ApplicationControllerTests.swift
+++ b/Tests/ApplicationControllerTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Syncalicious
+
+class TestApplicationDelegate: ApplicationControllerDelegate {
+  var applications = [Application]()
+  func applicationController(_ controller: ApplicationController, didLoadApplications applications: [Application]) {
+    self.applications = applications
+  }
+}
+
+class ApplicationControllerTests: XCTestCase {
+  let testController = TestController()
+
+  func testApplicationParsing() {
+    let delegate = TestApplicationDelegate()
+    let applicationController = testController.createApplicationController()
+    applicationController.delegate = delegate
+    applicationController.loadApplications(at: [
+      testController.environmentUrl.appendingPathComponent("Applications")
+    ])
+
+    if delegate.applications.count != 4 {
+      XCTAssertEqual(delegate.applications.count, 4)
+      return
+    }
+
+    XCTAssertEqual(delegate.applications[0].propertyList.bundleIdentifier,
+                   "com.zenangst.Syncalicious.TestAppWithSUDefaultsDomain")
+    XCTAssertEqual(delegate.applications[1].propertyList.bundleIdentifier,
+                   "com.zenangst.Syncalicious.ContainerTestAppSUDefaultsDomain")
+    XCTAssertEqual(delegate.applications[2].propertyList.bundleIdentifier,
+                   "com.zenangst.Syncalicious.ContainerTestApp")
+    XCTAssertEqual(delegate.applications[3].propertyList.bundleIdentifier,
+                   "com.zenangst.Syncalicious.TestApp")
+
+  }
+}

--- a/Tests/TestController.swift
+++ b/Tests/TestController.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import Syncalicious
+
+class TestController {
+  var environmentUrl: URL!
+
+  init() {
+    guard let environmentPath = ProcessInfo.processInfo.environment["EnvironmentPath"] else {
+      XCTFail("Couldn't find EnvironmentPath")
+      return
+    }
+    environmentUrl = URL(string: environmentPath)!
+  }
+
+  func createApplicationController() -> ApplicationController {
+    let libraryDirectory = environmentUrl.appendingPathComponent("Library")
+    let preferencesController = PreferencesController(libraryDirectory: libraryDirectory)
+    let infoPlistController = InfoPropertyListController()
+    let applicationController = ApplicationController(infoPlistController: infoPlistController,
+                                                      preferencesController: preferencesController)
+
+    return applicationController
+  }
+}

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -1,8 +1,0 @@
-import XCTest
-import Syncalicious
-
-class Tests: XCTestCase {
-  func test() {
-    XCTAssertTrue(true)
-  }
-}


### PR DESCRIPTION
- Refactors implementation to be more testable by injecting environment urls
- Adds `ApplicationControllerTests` which starts testing application scanning and plist parsing
- Adds initial test environment with dummy apps and plist files