### PR TITLE
Add bundleName to InfoPropertyList

### DIFF
--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -113,8 +113,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, BackupControllerDelegate, Ap
     dependencyContainer?.backupController.applications = applications
 
     let models = applications.compactMap({
-      ApplicationItemModel(title: $0.propertyList.bundleIdentifier,
-                           subtitle: $0.preferences.path.path,
+      ApplicationItemModel(title: $0.propertyList.bundleName,
+                           subtitle: $0.propertyList.bundleIdentifier,
                            bundleIdentifier: $0.propertyList.bundleIdentifier,
                            path: $0.path)
     })

--- a/Sources/Controllers/InfoPropertyListController.swift
+++ b/Sources/Controllers/InfoPropertyListController.swift
@@ -21,9 +21,11 @@ class InfoPropertyListController {
       throw InfoPropertyListError.unableToResolveBundleIdentifier
     }
 
+    let bundleName = contents.value(forPropertyListKey: .bundleName) ?? bundleIdentifier
     let defaultsDomain = contents.value(forPropertyListKey: .defaultsDomain)
 
     return InfoPropertyList(bundleIdentifier: bundleIdentifier,
+                            bundleName: bundleName,
                             defaultsDomain: defaultsDomain,
                             path: path)
   }

--- a/Sources/Models/InfoPropertyList.swift
+++ b/Sources/Models/InfoPropertyList.swift
@@ -1,15 +1,16 @@
 import Foundation
 
 enum InfoPropertyListKey: String {
+  case bundleIdentifier = "CFBundleIdentifier"
   case bundleName = "CFBundleName"
+  case defaultsDomain = "SUDefaultsDomain"
   case executableName = "CFBundleExecutable"
   case iconFile = "CFBundleIconFile"
-  case bundleIdentifier = "CFBundleIdentifier"
-  case defaultsDomain = "SUDefaultsDomain"
 }
 
 struct InfoPropertyList {
   let bundleIdentifier: String
+  let bundleName: String
   let defaultsDomain: String?
   let path: String
 }


### PR DESCRIPTION
The UI will now use the `CFBundleName` instead of the bundle identifier.

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/57446/55570402-aa963580-5703-11e9-8bd4-929d9d054007.png">
