### PR TITLE
Add initial implementation of sync feature

### DIFF
--- a/Sources/Controllers/MachineController.swift
+++ b/Sources/Controllers/MachineController.swift
@@ -21,6 +21,15 @@ class MachineController {
                            localizedName: localizedName)
   }
 
+  func createMachineBackupDestinationIfNeeded(at destination: URL) throws {
+    let url = machineBackupDestination(for: destination)
+    if !FileManager.default.fileExists(atPath: url.path) {
+      try FileManager.default.createDirectory(at: url,
+                                              withIntermediateDirectories: true,
+                                              attributes: nil)
+    }
+  }
+
   func machineBackupDestination(for destination: URL) -> URL {
     return destination.appendingPathComponent(machine.name)
   }

--- a/Sources/Features/BackupController.swift
+++ b/Sources/Features/BackupController.swift
@@ -64,7 +64,9 @@ class BackupController {
     }
 
     do {
-      try fileManager.createDirectory(at: backupLocation, withIntermediateDirectories: true, attributes: nil)
+      try fileManager.createDirectory(at: backupLocation,
+                                      withIntermediateDirectories: true,
+                                      attributes: nil)
       debugPrint("Created directory at: \(backupLocation.path)")
     } catch let error {
       throw BackupError.unableToCreateBackupFolder(error)

--- a/Sources/Features/SyncController.swift
+++ b/Sources/Features/SyncController.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+class SyncController {
+  let destination: URL
+  let applicationController: ApplicationController
+  let fileManager = FileManager.default
+
+  init(applicationController: ApplicationController, destination: URL) {
+    self.applicationController = applicationController
+    self.destination = destination
+  }
+
+  // MARK: - Public methods
+
+  func enableSync(for application: Application, on machine: Machine) throws {
+    try createSyncBackup(for: application, on: machine)
+    let storage = try createStorageFolderIfNeeded()
+    let storageUrl = copyPropertyList(for: application, to: storage)
+    try createSymlink(for: application, to: storageUrl)
+  }
+
+  func disableSync(for application: Application, on machine: Machine) throws {
+    let backup = destination
+      .appendingPathComponent(machine.name)
+      .appendingPathComponent(application.preferences.path.lastPathComponent)
+    try replaceSymlinkWithRegularFile(for: application, to: backup)
+    try fileManager.removeItem(at: backup)
+  }
+
+  // MARK: - Private methods
+
+  private func createSyncBackup(for application: Application, on machine: Machine) throws {
+    var from = application.preferences.path
+    from.resolveSymlinksInPath()
+
+    let toDestination = destination
+      .appendingPathComponent(machine.name)
+      .appendingPathComponent(from.lastPathComponent)
+
+    try fileManager.copyItem(at: from, to: toDestination)
+  }
+
+  private func createStorageFolderIfNeeded() throws -> URL {
+    let storageDestination = destination.appendingPathComponent("Storage")
+    try fileManager.createDirectory(at: storageDestination,
+                                    withIntermediateDirectories: true,
+                                    attributes: nil)
+    return storageDestination
+  }
+
+  private func copyPropertyList(for application: Application, to url: URL) -> URL {
+    let destination = url.appendingPathComponent(application.preferences.path.lastPathComponent)
+    try? fileManager.copyItem(at: application.preferences.path, to: destination)
+    return destination
+  }
+
+  private func createSymlink(for application: Application, to url: URL) throws {
+    try fileManager.removeItem(at: application.preferences.path)
+    try fileManager.createSymbolicLink(at: application.preferences.path, withDestinationURL: url)
+  }
+
+  private func replaceSymlinkWithRegularFile(for application: Application, to url: URL) throws {
+    try fileManager.removeItem(at: application.preferences.path)
+    try fileManager.copyItem(at: url, to: application.preferences.path)
+  }
+}

--- a/Syncalicious.xcodeproj/project.pbxproj
+++ b/Syncalicious.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD084B722258D92D00E91A7F /* SyncController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD084B712258D92D00E91A7F /* SyncController.swift */; };
+		BD084B742258DA7800E91A7F /* SyncControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD084B732258DA7800E91A7F /* SyncControllerTests.swift */; };
+		BD084B772258E07C00E91A7F /* TestApplicationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD084B762258E07C00E91A7F /* TestApplicationDelegate.swift */; };
+		BD084B792258E0B600E91A7F /* TestHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD084B782258E0B600E91A7F /* TestHost.swift */; };
 		BD4A692F2253BA6400F588AD /* Machine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A692E2253BA6400F588AD /* Machine.swift */; };
 		BD4A69312253BADE00F588AD /* MachineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A69302253BADE00F588AD /* MachineController.swift */; };
 		BD4A693A2253DCF300F588AD /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A69392253DCF100F588AD /* MainWindow.swift */; };
@@ -47,6 +51,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BD084B712258D92D00E91A7F /* SyncController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncController.swift; sourceTree = "<group>"; };
+		BD084B732258DA7800E91A7F /* SyncControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncControllerTests.swift; sourceTree = "<group>"; };
+		BD084B762258E07C00E91A7F /* TestApplicationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestApplicationDelegate.swift; sourceTree = "<group>"; };
+		BD084B782258E0B600E91A7F /* TestHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHost.swift; sourceTree = "<group>"; };
 		BD4A692E2253BA6400F588AD /* Machine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Machine.swift; sourceTree = "<group>"; };
 		BD4A69302253BADE00F588AD /* MachineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MachineController.swift; path = Sources/Controllers/MachineController.swift; sourceTree = SOURCE_ROOT; };
 		BD4A69322253D8F800F588AD /* .travis.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
@@ -104,6 +112,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BD084B752258E06E00E91A7F /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				BD8EDD712255322A00110E56 /* TestController.swift */,
+				BD084B762258E07C00E91A7F /* TestApplicationDelegate.swift */,
+				BD084B782258E0B600E91A7F /* TestHost.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		BD4A69382253DCF100F588AD /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -173,6 +191,7 @@
 			children = (
 				BD7D961B22532B6900C93211 /* BackupController.swift */,
 				BD8EDD812255CE3400110E56 /* IconController.swift */,
+				BD084B712258D92D00E91A7F /* SyncController.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -269,8 +288,9 @@
 		BDCBB2A922551372007C9404 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				BD084B752258E06E00E91A7F /* Helpers */,
 				BDCBB2AA22551372007C9404 /* ApplicationControllerTests.swift */,
-				BD8EDD712255322A00110E56 /* TestController.swift */,
+				BD084B732258DA7800E91A7F /* SyncControllerTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -412,6 +432,7 @@
 				BD4A692F2253BA6400F588AD /* Machine.swift in Sources */,
 				BD4A693A2253DCF300F588AD /* MainWindow.swift in Sources */,
 				BD8EDD822255CE3400110E56 /* IconController.swift in Sources */,
+				BD084B722258D92D00E91A7F /* SyncController.swift in Sources */,
 				BD4A69312253BADE00F588AD /* MachineController.swift in Sources */,
 				BD4A6941225406A300F588AD /* ViewController.swift in Sources */,
 				BD8EDD7E22553ADD00110E56 /* ApplicationView.swift in Sources */,
@@ -433,7 +454,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDCBB2AB22551372007C9404 /* ApplicationControllerTests.swift in Sources */,
+				BD084B792258E0B600E91A7F /* TestHost.swift in Sources */,
+				BD084B742258DA7800E91A7F /* SyncControllerTests.swift in Sources */,
 				BD8EDD722255322A00110E56 /* TestController.swift in Sources */,
+				BD084B772258E07C00E91A7F /* TestApplicationDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/ApplicationControllerTests.swift
+++ b/Tests/ApplicationControllerTests.swift
@@ -1,15 +1,8 @@
 import XCTest
 @testable import Syncalicious
 
-class TestApplicationDelegate: ApplicationControllerDelegate {
-  var applications = [Application]()
-  func applicationController(_ controller: ApplicationController, didLoadApplications applications: [Application]) {
-    self.applications = applications
-  }
-}
-
 class ApplicationControllerTests: XCTestCase {
-  let testController = TestController()
+  let testController = try! TestController()
 
   func testApplicationParsing() {
     let delegate = TestApplicationDelegate()

--- a/Tests/Helpers/TestApplicationDelegate.swift
+++ b/Tests/Helpers/TestApplicationDelegate.swift
@@ -1,0 +1,8 @@
+@testable import Syncalicious
+
+class TestApplicationDelegate: ApplicationControllerDelegate {
+  var applications = [Application]()
+  func applicationController(_ controller: ApplicationController, didLoadApplications applications: [Application]) {
+    self.applications = applications
+  }
+}

--- a/Tests/Helpers/TestController.swift
+++ b/Tests/Helpers/TestController.swift
@@ -1,15 +1,18 @@
-import XCTest
+import Foundation
 @testable import Syncalicious
 
-class TestController {
-  var environmentUrl: URL!
+enum TestControllerError: Error {
+  case unableToFindEnvironmentPath
+}
 
-  init() {
+class TestController {
+  var environmentUrl: URL
+
+  required init() throws {
     guard let environmentPath = ProcessInfo.processInfo.environment["EnvironmentPath"] else {
-      XCTFail("Couldn't find EnvironmentPath")
-      return
+      throw TestControllerError.unableToFindEnvironmentPath
     }
-    environmentUrl = URL(string: environmentPath)!
+    self.environmentUrl = URL(string: "file://" + environmentPath)!
   }
 
   func createApplicationController() -> ApplicationController {

--- a/Tests/Helpers/TestHost.swift
+++ b/Tests/Helpers/TestHost.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+class TestHost: Host {
+  let machineName: String
+
+  override var name: String { return machineName + ".local" }
+  override var localizedName: String { return machineName }
+
+  required init(machineName: String) {
+    self.machineName = machineName
+    super.init()
+  }
+}

--- a/Tests/SyncControllerTests.swift
+++ b/Tests/SyncControllerTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Syncalicious
+
+class SyncControllerTests: XCTestCase {
+  let testController = try! TestController()
+
+  func testSyncingMachines() {
+    let environmentUrl = testController.environmentUrl
+    let syncUrl = environmentUrl.appendingPathComponent("Sync")
+    let applicationController = testController.createApplicationController()
+    let delegate = TestApplicationDelegate()
+
+    applicationController.delegate = delegate
+    applicationController.loadApplications(at: [
+      testController.environmentUrl.appendingPathComponent("Applications")
+      ])
+
+    let syncController = SyncController(applicationController: applicationController, destination: syncUrl)
+    let machineHostA = TestHost(machineName: "MachineA")
+    let machineHostB = TestHost(machineName: "MachineB")
+
+    do {
+      let machineContorllerA = try MachineController(host: machineHostA)
+      let machineContorllerB = try MachineController(host: machineHostB)
+
+      try machineContorllerA.createMachineBackupDestinationIfNeeded(at: syncUrl)
+      try machineContorllerB.createMachineBackupDestinationIfNeeded(at: syncUrl)
+
+      // TestApp
+      let application = delegate.applications[3]
+      let preferensLocation = application.preferences.path.path
+
+      var attributes = try FileManager.default.attributesOfItem(atPath: preferensLocation)
+      XCTAssertEqual((attributes as NSDictionary).fileType(), "NSFileTypeRegular")
+
+      try syncController.enableSync(for: application, on: machineContorllerA.machine)
+      attributes = try FileManager.default.attributesOfItem(atPath: preferensLocation)
+      XCTAssertEqual((attributes as NSDictionary).fileType(), "NSFileTypeSymbolicLink")
+
+      try syncController.disableSync(for: application, on: machineContorllerA.machine)
+      attributes = try FileManager.default.attributesOfItem(atPath: preferensLocation)
+      XCTAssertEqual((attributes as NSDictionary).fileType(), "NSFileTypeRegular")
+    } catch let error {
+      XCTFail(error.localizedDescription)
+    }
+  }
+}


### PR DESCRIPTION
Adds a new SyncController class, this class is in charge of handling the sync setups and desyncing on an app-per-app basis. When the sync is enabled for an application the following steps are performed:

- Backup the current configuration file in a directory using the current computer name.
- Create a Storage directory if it doesn't already exist.
- Copies the property list into the sync folder (only if it doesn't already exist)
- Removes the current plist and creates a symlink pointing to the sync folder.

When an application is marked as unsynchronised, the following occurs:

- Remove the symlinked preferences file
- Copy the sync backup file to the preference file location
- Remove the sync backup file for that specific computer