### PR TITLE
Set frame size of window to minimum size on first run

### DIFF
--- a/Sources/Views/MainWindow.swift
+++ b/Sources/Views/MainWindow.swift
@@ -8,5 +8,10 @@ class MainWindow: NSWindow {
     titleVisibility = .hidden
     toolbar = Toolbar(identifier: String.init(describing: self))
     minSize = windowSize
+
+    if frame.size.width < windowSize.width || frame.size.width > maxSize.width {
+      setFrame(NSRect.init(origin: .zero, size: windowSize),
+               display: false)
+    }
   }
 }


### PR DESCRIPTION
Fixes issue that the main window doesn't have a proper size the first time the app runs.