### PR TITLE
Lowercase the bundle name before sorting

### DIFF
--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -149,7 +149,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, BackupControllerDelegate, Ap
     dependencyContainer?.backupController.applications = applications
 
     let models = applications
-      .sorted(by: { $0.propertyList.bundleName < $1.propertyList.bundleName })
+      .sorted(by: { $0.propertyList.bundleName.lowercased() < $1.propertyList.bundleName.lowercased() })
       .compactMap({
         ApplicationItemModel(data: [
           "title": $0.propertyList.bundleName,


### PR DESCRIPTION
- Fixes issue where apps that start with a lowercase letter; like iTunes, ended up last in the list.