### PR TITLE
Introduce factories

### DIFF
--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -41,8 +41,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, BackupControllerDelegate, Ap
 
       let dependencyContainer = try createDependencyContainer()
       let locations = try dependencyContainer.applicationController.applicationDirectories()
-      let windowController = createWindowController(dependencyContainer: dependencyContainer)
-
+      let (windowController, listController) = dependencyContainer.windowFactory.createMainWindowControllers()
+      self.mainViewController = listController
       self.mainMenuController?.dependencyContainer = dependencyContainer
       self.window = windowController.window
       self.dependencyContainer = dependencyContainer
@@ -57,55 +57,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, BackupControllerDelegate, Ap
       let alert = NSAlert(error: error)
       alert.runModal()
     }
-  }
-
-  private func createWindowController(dependencyContainer: DependencyContainer) -> NSWindowController {
-    let layout = NSCollectionViewFlowLayout()
-    layout.sectionInset = .init(top: 10, left: 10, bottom: 10, right: 10)
-    layout.minimumLineSpacing = 0
-    layout.itemSize = .init(width: 250, height: 48)
-    let listController = ApplicationItemViewController(layout: layout, iconStore: dependencyContainer)
-    listController.view.wantsLayer = true
-    listController.view.layer?.backgroundColor = NSColor.white.cgColor
-    listController.title = Bundle.main.infoDictionary?["CFBundleName"] as? String
-
-    self.mainViewController = listController
-
-    let window = MainWindow.init()
-    window.loadWindow()
-    window.setFrameAutosaveName(Bundle.main.bundleIdentifier!)
-
-    Swift.print(layout.itemSize.width + layout.sectionInset.left + layout.sectionInset.right)
-
-    let sidebarItem = NSSplitViewItem(contentListWithViewController: listController)
-    sidebarItem.holdingPriority = .init(rawValue: 260)
-    sidebarItem.minimumThickness = layout.itemSize.width + layout.sectionInset.left + layout.sectionInset.right
-    sidebarItem.maximumThickness = sidebarItem.minimumThickness
-    sidebarItem.canCollapse = true
-
-    let detailViewController = ViewController()
-    detailViewController.view.wantsLayer = true
-    detailViewController.view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
-    detailViewController.title = "Customize"
-
-    let detailControllerItem = NSSplitViewItem(viewController: detailViewController)
-    detailControllerItem.minimumThickness = 320
-    detailControllerItem.canCollapse = false
-
-    let inspectorController = ViewController()
-    inspectorController.view.wantsLayer = true
-    inspectorController.view.layer?.backgroundColor = NSColor.white.cgColor
-
-    let inspectorControllerItem = NSSplitViewItem(viewController: inspectorController)
-    inspectorControllerItem.holdingPriority = .init(rawValue: 260)
-    inspectorControllerItem.minimumThickness = 260
-    inspectorControllerItem.maximumThickness = 260
-    inspectorControllerItem.canCollapse = true
-
-    let windowController = WindowController(window: window,
-                                            with: [sidebarItem, detailControllerItem])
-
-    return windowController
   }
 
   private func createDependencyContainer() throws -> DependencyContainer {

--- a/Sources/Application/DependencyContainer.swift
+++ b/Sources/Application/DependencyContainer.swift
@@ -1,6 +1,11 @@
 import Cocoa
 
 class DependencyContainer: IconStore {
+  lazy var layoutFactory = CollectionViewLayoutFactory()
+  lazy var viewControllerFactory = ViewControllerFactory(dependencyContainer: self)
+  lazy var windowFactory = WindowFactory(dependencyContainer: self,
+                                         layoutFactory: layoutFactory,
+                                         viewControllerFactory: viewControllerFactory)
   let applicationController: ApplicationController
   let backupController: BackupController
   let iconController: IconController

--- a/Sources/Application/MainMenuController.swift
+++ b/Sources/Application/MainMenuController.swift
@@ -10,35 +10,20 @@ class MainMenuController: NSObject {
   }
 
   @IBAction func performBackup(_ sender: Any?) {
+    guard let windowFactory = dependencyContainer?.windowFactory else { return }
+
     guard let backupDestination = UserDefaults.standard.backupDestination else {
       let message = NSLocalizedString("You need to pick a backup destination before you can make a backup.",
                                       comment: "")
-      let alert = createAlert(with: message)
+      let alert = windowFactory.createAlert(with: message)
       alert.runModal()
       return
     }
     do {
       try dependencyContainer?.backupController.initializeBackup(to: backupDestination)
     } catch let error {
-      let alert = createAlert(error: error)
+      let alert = windowFactory.createAlert(error: error)
       alert.runModal()
     }
-  }
-
-  // MARK: - Private methods
-
-  private func createAlert(with text: String = "", error: Error? = nil) -> NSAlert {
-    let alert: NSAlert
-    if let error = error {
-      alert = NSAlert(error: error)
-    } else {
-      alert = NSAlert()
-      alert.messageText = text
-    }
-
-    alert.alertStyle = .warning
-    alert.addButton(withTitle: "Ok")
-
-    return alert
   }
 }

--- a/Sources/Factories/CollectionViewLayoutFactory.swift
+++ b/Sources/Factories/CollectionViewLayoutFactory.swift
@@ -1,0 +1,12 @@
+import Cocoa
+
+class CollectionViewLayoutFactory {
+  func createApplicationListLayout() -> NSCollectionViewFlowLayout {
+    let layout = NSCollectionViewFlowLayout()
+    layout.sectionInset = .init(top: 10, left: 10, bottom: 10, right: 10)
+    layout.minimumLineSpacing = 0
+    layout.itemSize = .init(width: 250, height: 48)
+
+    return layout
+  }
+}

--- a/Sources/Factories/ViewControllerFactory.swift
+++ b/Sources/Factories/ViewControllerFactory.swift
@@ -1,0 +1,18 @@
+import Cocoa
+
+class ViewControllerFactory {
+  weak var dependencyContainer: DependencyContainer!
+
+  init(dependencyContainer: DependencyContainer) {
+    self.dependencyContainer = dependencyContainer
+  }
+
+  func createApplicationListViewController(with layout: NSCollectionViewFlowLayout) -> ApplicationItemViewController {
+    let listViewController = ApplicationItemViewController(layout: layout, iconStore: dependencyContainer)
+    listViewController.view.wantsLayer = true
+    listViewController.view.layer?.backgroundColor = NSColor.white.cgColor
+    listViewController.title = Bundle.main.infoDictionary?["CFBundleName"] as? String
+
+    return listViewController
+  }
+}

--- a/Sources/Factories/WindowFactory.swift
+++ b/Sources/Factories/WindowFactory.swift
@@ -1,0 +1,73 @@
+import Cocoa
+
+class WindowFactory {
+  weak var dependencyContainer: DependencyContainer!
+  weak var layoutFactory: CollectionViewLayoutFactory!
+  weak var viewControllerFactory: ViewControllerFactory!
+
+  init(dependencyContainer: DependencyContainer,
+       layoutFactory: CollectionViewLayoutFactory,
+       viewControllerFactory: ViewControllerFactory) {
+    self.dependencyContainer = dependencyContainer
+    self.layoutFactory = layoutFactory
+    self.viewControllerFactory = viewControllerFactory
+  }
+
+  func createMainWindow() -> MainWindow {
+    let window = MainWindow()
+    window.loadWindow()
+    window.setFrameAutosaveName(Bundle.main.bundleIdentifier!)
+    return window
+  }
+
+  func createMainWindowControllers() -> (NSWindowController, ApplicationItemViewController) {
+    let window = createMainWindow()
+    let layout = layoutFactory.createApplicationListLayout()
+    let listViewController = viewControllerFactory.createApplicationListViewController(with: layout)
+
+    let sidebarItem = NSSplitViewItem(contentListWithViewController: listViewController)
+    sidebarItem.holdingPriority = .init(rawValue: 260)
+    sidebarItem.minimumThickness = layout.itemSize.width + layout.sectionInset.left + layout.sectionInset.right
+    sidebarItem.maximumThickness = sidebarItem.minimumThickness
+    sidebarItem.canCollapse = true
+
+    let detailViewController = ViewController()
+    detailViewController.view.wantsLayer = true
+    detailViewController.view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+    detailViewController.title = "Customize"
+
+    let detailControllerItem = NSSplitViewItem(viewController: detailViewController)
+    detailControllerItem.minimumThickness = 320
+    detailControllerItem.canCollapse = false
+
+    let inspectorController = ViewController()
+    inspectorController.view.wantsLayer = true
+    inspectorController.view.layer?.backgroundColor = NSColor.white.cgColor
+
+    let inspectorControllerItem = NSSplitViewItem(viewController: inspectorController)
+    inspectorControllerItem.holdingPriority = .init(rawValue: 260)
+    inspectorControllerItem.minimumThickness = 260
+    inspectorControllerItem.maximumThickness = 260
+    inspectorControllerItem.canCollapse = true
+
+    let windowController = WindowController(window: window,
+                                            with: [sidebarItem, detailControllerItem])
+
+    return (windowController, listViewController)
+  }
+
+  func createAlert(with text: String = "", error: Error? = nil) -> NSAlert {
+    let alert: NSAlert
+    if let error = error {
+      alert = NSAlert(error: error)
+    } else {
+      alert = NSAlert()
+      alert.messageText = text
+    }
+
+    alert.alertStyle = .warning
+    alert.addButton(withTitle: "Ok")
+
+    return alert
+  }
+}

--- a/Syncalicious.xcodeproj/project.pbxproj
+++ b/Syncalicious.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		BDDAA337225D37D100D87664 /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA336225D37D100D87664 /* BackgroundView.swift */; };
 		BDDAA339225D37DE00D87664 /* DividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA338225D37DE00D87664 /* DividerView.swift */; };
 		BDDAA33B225D383400D87664 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA33A225D383400D87664 /* Label.swift */; };
+		BDDAA33E225DB56B00D87664 /* WindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA33D225DB56B00D87664 /* WindowFactory.swift */; };
+		BDDAA340225DB57500D87664 /* ViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA33F225DB57500D87664 /* ViewControllerFactory.swift */; };
+		BDDAA342225DB79300D87664 /* CollectionViewLayoutFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA341225DB79300D87664 /* CollectionViewLayoutFactory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -114,6 +117,9 @@
 		BDDAA336225D37D100D87664 /* BackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
 		BDDAA338225D37DE00D87664 /* DividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerView.swift; sourceTree = "<group>"; };
 		BDDAA33A225D383400D87664 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
+		BDDAA33D225DB56B00D87664 /* WindowFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowFactory.swift; sourceTree = "<group>"; };
+		BDDAA33F225DB57500D87664 /* ViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerFactory.swift; sourceTree = "<group>"; };
+		BDDAA341225DB79300D87664 /* CollectionViewLayoutFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewLayoutFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -302,6 +308,7 @@
 				BD7D960F225288B700C93211 /* Application */,
 				BD7D9611225288C100C93211 /* Controllers */,
 				BD7D961D22532B8F00C93211 /* Extensions */,
+				BDDAA33C225DB55A00D87664 /* Factories */,
 				BD7D961A22532B5900C93211 /* Features */,
 				BD7D9610225288BD00C93211 /* Models */,
 				BD8EDD872255CF6A00110E56 /* Protocols */,
@@ -319,6 +326,16 @@
 				BD084B732258DA7800E91A7F /* SyncControllerTests.swift */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		BDDAA33C225DB55A00D87664 /* Factories */ = {
+			isa = PBXGroup;
+			children = (
+				BDDAA341225DB79300D87664 /* CollectionViewLayoutFactory.swift */,
+				BDDAA33F225DB57500D87664 /* ViewControllerFactory.swift */,
+				BDDAA33D225DB56B00D87664 /* WindowFactory.swift */,
+			);
+			path = Factories;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -456,6 +473,7 @@
 				BD7D961C22532B6900C93211 /* BackupController.swift in Sources */,
 				BDDAA333225D37BD00D87664 /* LayeredView.swift in Sources */,
 				BD4A692F2253BA6400F588AD /* Machine.swift in Sources */,
+				BDDAA340225DB57500D87664 /* ViewControllerFactory.swift in Sources */,
 				BD895C03225A681D00DEC9FE /* PrototypeView.swift in Sources */,
 				BD895C08225A698600DEC9FE /* PrototypeItemComponent.generated.swift in Sources */,
 				BDDAA337225D37D100D87664 /* BackgroundView.swift in Sources */,
@@ -474,8 +492,10 @@
 				BDDAA339225D37DE00D87664 /* DividerView.swift in Sources */,
 				BD895C01225A67C200DEC9FE /* PrototypeItem.swift in Sources */,
 				BD7D960C2252849100C93211 /* ApplicationController.swift in Sources */,
+				BDDAA342225DB79300D87664 /* CollectionViewLayoutFactory.swift in Sources */,
 				BD8EDD892255CF7500110E56 /* Component.swift in Sources */,
 				BD8EDD7A22553A5A00110E56 /* CollectionViewItemComponent.swift in Sources */,
+				BDDAA33E225DB56B00D87664 /* WindowFactory.swift in Sources */,
 				BD7D962322533FF300C93211 /* MainMenuController.swift in Sources */,
 				BD8EDD862255CF4800110E56 /* CollectionViewItemComponent.generated.swift in Sources */,
 				BD7D961322528ADB00C93211 /* InfoPropertyList.swift in Sources */,


### PR DESCRIPTION
- Adds `CollectionViewLayoutFactory` for creating layouts
- Adds `ViewControllerFactory` for constructing view controllers
- Adds `WindowFactory` windows, window controllers and alerts.

The motivation behind this PR is to contain the creation of objects into their rightful place. It offloads the application delegate with all application creation and separates the concerns. This will be more useful in the future for things like third-party dependency containment.