### PR TITLE
Improve application list

### DIFF
--- a/Sources/Application/AppDelegate.swift
+++ b/Sources/Application/AppDelegate.swift
@@ -99,17 +99,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, BackupControllerDelegate, Ap
                              didLoadApplications applications: [Application]) {
     dependencyContainer?.backupController.applications = applications
 
+    let closure: (Application) -> ApplicationItemModel = { item in
+      var subtitle = "\(item.propertyList.versionString)"
+      if !item.propertyList.buildVersion.isEmpty && item.propertyList.versionString != item.propertyList.buildVersion {
+        subtitle.append(" (\(item.propertyList.buildVersion))")
+      }
+
+      return ApplicationItemModel(data: [
+        "title": item.propertyList.bundleName,
+        "subtitle": subtitle,
+        "bundleIdentifier": item.propertyList.bundleIdentifier,
+        "path": item.path,
+        "enabled": true
+        ])
+    }
     let models = applications
       .sorted(by: { $0.propertyList.bundleName.lowercased() < $1.propertyList.bundleName.lowercased() })
-      .compactMap({
-        ApplicationItemModel(data: [
-          "title": $0.propertyList.bundleName,
-          "subtitle": $0.propertyList.bundleIdentifier,
-          "bundleIdentifier": $0.propertyList.bundleIdentifier,
-          "path": $0.path,
-          "enabled": true
-          ])
-    })
+      .compactMap(closure)
 
     if let mainViewController = mainViewController {
       mainViewController.reload(with: models)

--- a/Sources/Controllers/InfoPropertyListController.swift
+++ b/Sources/Controllers/InfoPropertyListController.swift
@@ -21,13 +21,17 @@ class InfoPropertyListController {
       throw InfoPropertyListError.unableToResolveBundleIdentifier
     }
 
+    let buildVersion = contents.value(forPropertyListKey: .buildVersion) ?? bundleIdentifier
     let bundleName = contents.value(forPropertyListKey: .bundleName) ?? bundleIdentifier
     let defaultsDomain = contents.value(forPropertyListKey: .defaultsDomain)
+    let versionString = contents.value(forPropertyListKey: .versionString) ?? ""
 
-    return InfoPropertyList(bundleIdentifier: bundleIdentifier,
+    return InfoPropertyList(buildVersion: buildVersion,
+                            bundleIdentifier: bundleIdentifier,
                             bundleName: bundleName,
                             defaultsDomain: defaultsDomain,
-                            path: path)
+                            path: path,
+                            versionString: versionString)
   }
 }
 

--- a/Sources/Models/InfoPropertyList.swift
+++ b/Sources/Models/InfoPropertyList.swift
@@ -1,16 +1,20 @@
 import Foundation
 
 enum InfoPropertyListKey: String {
+  case buildVersion = "CFBundleVersion"
   case bundleIdentifier = "CFBundleIdentifier"
   case bundleName = "CFBundleName"
   case defaultsDomain = "SUDefaultsDomain"
   case executableName = "CFBundleExecutable"
   case iconFile = "CFBundleIconFile"
+  case versionString = "CFBundleShortVersionString"
 }
 
 struct InfoPropertyList {
+  let buildVersion: String
   let bundleIdentifier: String
   let bundleName: String
   let defaultsDomain: String?
   let path: String
+  let versionString: String
 }


### PR DESCRIPTION
- Adds `bundleVersion` and `versionString` to `InfoPropertyList`
- Use version(s) instead of bundle identifier in list of applications

<img width="877" alt="image" src="https://user-images.githubusercontent.com/57446/55857045-64f6c400-5b6c-11e9-8908-4017f606d429.png">
