### PR TITLE
Fix splitView offset rendering

### DIFF
--- a/Sources/Controllers/SplitViewController.swift
+++ b/Sources/Controllers/SplitViewController.swift
@@ -31,7 +31,7 @@ class SplitViewController: NSSplitViewController {
     NSLayoutConstraint.deactivate(layoutConstraints)
     splitView.translatesAutoresizingMaskIntoConstraints = false
     layoutConstraints = [
-      splitView.topAnchor.constraint(equalTo: view.topAnchor, constant: 40),
+      splitView.topAnchor.constraint(equalTo: view.topAnchor, constant: 38),
       splitView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
       splitView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
       splitView.bottomAnchor.constraint(equalTo: view.bottomAnchor)


### PR DESCRIPTION
The split view was rendered with 2 pixel offset, this is fixed by changing the constraints to 38 instead of 40.