### PR TITLE
Set background color to computer view controller

### DIFF
--- a/Sources/Features/Detail/DetailContainerViewController.swift
+++ b/Sources/Features/Detail/DetailContainerViewController.swift
@@ -40,6 +40,7 @@ class DetailContainerViewController: FamilyViewController {
         .margin(.init(top: 15, left: 30, bottom: 0, right: 30))
       add(generalActionsViewController)
       add(computersViewController, view: { $0.collectionView })
+        .background(.color(NSColor.windowBackgroundColor))
     }
 
     computersViewController.collectionView.backgroundColors = [NSColor.windowBackgroundColor]


### PR DESCRIPTION
Fixes visual bug where the computer view doesn't get a background color that stretches the entire width.

## Before
<img width="845" alt="image" src="https://user-images.githubusercontent.com/57446/64350856-a09d9900-cff9-11e9-8f1b-6b8dd448ea7a.png">

## After

<img width="845" alt="image" src="https://user-images.githubusercontent.com/57446/64350886-b0b57880-cff9-11e9-9a77-87683b19b2bd.png">
