### PR TITLE
Improve UI to support dark mode

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -29,6 +29,6 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSRequiresAquaSystemAppearance</key>
-	<true/>
+	<false/>
 </dict>
 </plist>

--- a/Sources/Controllers/SplitViewController.swift
+++ b/Sources/Controllers/SplitViewController.swift
@@ -3,9 +3,22 @@ import Cocoa
 class SplitViewController: NSSplitViewController {
   private var layoutConstraints = [NSLayoutConstraint]()
 
+  override func loadView() {
+    self.splitView = SplitView()
+
+    super.loadView()
+
+    let visualEffect = NSVisualEffectView()
+    visualEffect.blendingMode = .behindWindow
+    visualEffect.state = .followsWindowActiveState
+    visualEffect.material = .contentBackground
+    self.view = view
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
     configureViews()
+
     NotificationCenter.default.addObserver(self, selector: #selector(mainWindowDidResignKey),
                                            name: MainWindowNotification.didResign.notificationName,
                                            object: nil)
@@ -19,15 +32,12 @@ class SplitViewController: NSSplitViewController {
     super.viewWillLayout()
     let dividers = view.subviews.compactMap({ $0 as? DividerView })
     let lightDividers = view.subviews.compactMap({ $0 as? LightDividerView })
-    let backgrounds = view.subviews.compactMap({ $0 as? BackgroundView })
 
     if view.effectiveAppearance.name == .aqua {
       dividers.forEach { $0.layer?.backgroundColor = NSColor(red: 0.87, green: 0.87, blue: 0.87, alpha: 1.00).cgColor }
-      backgrounds.forEach { $0.layer?.backgroundColor = $0.belongsToView?.layer?.backgroundColor }
       lightDividers.forEach { $0.layer?.backgroundColor = NSColor(red: 0.95, green: 0.95, blue: 0.95, alpha: 1.00).cgColor }
     } else {
       dividers.forEach { $0.layer?.backgroundColor = NSColor.black.cgColor }
-      backgrounds.forEach { $0.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor }
       lightDividers.forEach { $0.layer?.backgroundColor = NSColor.darkGray.cgColor }
     }
   }
@@ -36,7 +46,7 @@ class SplitViewController: NSSplitViewController {
     for item in splitViewItems {
       let viewController = item.viewController
       let containedViewController = viewController as? SplitViewContainedController
-      containedViewController?.titlebarView.alphaValue = 0.75
+      containedViewController?.titlebarView.subviews.forEach { $0.alphaValue = 0.75 }
     }
   }
 
@@ -44,7 +54,7 @@ class SplitViewController: NSSplitViewController {
     for item in splitViewItems {
       let viewController = item.viewController
       let containedViewController = viewController as? SplitViewContainedController
-      containedViewController?.titlebarView.alphaValue = 1.0
+      containedViewController?.titlebarView.subviews.forEach { $0.alphaValue = 1.0 }
     }
   }
 
@@ -64,7 +74,7 @@ class SplitViewController: NSSplitViewController {
       let viewController = item.viewController
       let view = viewController.view
 
-      let toolbarBackground = BackgroundView(cgColor: view.layer?.backgroundColor)
+      let toolbarBackground = BackgroundView(cgColor: NSColor.windowFrameColor.cgColor)
       toolbarBackground.belongsToView = view
       self.view.addSubview(toolbarBackground, positioned: .below, relativeTo: splitView)
 

--- a/Sources/Controllers/ViewController.swift
+++ b/Sources/Controllers/ViewController.swift
@@ -4,7 +4,7 @@ open class ViewController: NSViewController {
   var layoutConstraints = [NSLayoutConstraint]()
 
   open override func loadView() {
-    view = OpaqueView()
+    view = NSView()
     view.wantsLayer = true
   }
 

--- a/Sources/Factories/CollectionViewLayoutFactory.swift
+++ b/Sources/Factories/CollectionViewLayoutFactory.swift
@@ -31,7 +31,7 @@ class CollectionViewLayoutFactory {
 
   func createApplicationListLayout() -> NSCollectionViewFlowLayout {
     let layout = VerticalBlueprintLayout(itemsPerRow: 1,
-                                         height: 48,
+                                         height: 40,
                                          minimumInteritemSpacing: 0,
                                          minimumLineSpacing: 1,
                                          sectionInset: .init(top: 5, left: 0, bottom: 5, right: 0))

--- a/Sources/Factories/WindowFactory.swift
+++ b/Sources/Factories/WindowFactory.swift
@@ -26,16 +26,16 @@ class WindowFactory {
     let listViewController = viewControllerFactory.createApplicationListFeatureViewController(with: layout)
     listViewController.containerViewController.listViewController.collectionView.delegate = listViewController
 
-    let sidebarItem = NSSplitViewItem(contentListWithViewController: listViewController)
-    sidebarItem.holdingPriority = .init(rawValue: 260)
-    sidebarItem.minimumThickness = 260
+    let sidebarItem = NSSplitViewItem(viewController: listViewController)
+    sidebarItem.holdingPriority = .init(rawValue: 225)
+    sidebarItem.minimumThickness = 225
     sidebarItem.maximumThickness = sidebarItem.minimumThickness
     sidebarItem.canCollapse = true
 
     let detailViewController = viewControllerFactory.createApplicationDetailFeatureViewController()
     listViewController.delegate = detailViewController
 
-    let detailControllerItem = NSSplitViewItem(contentListWithViewController: detailViewController)
+    let detailControllerItem = NSSplitViewItem(viewController: detailViewController)
     detailControllerItem.minimumThickness = 320
     detailControllerItem.canCollapse = false
 

--- a/Sources/Features/Application List/ApplicationListItem.swift
+++ b/Sources/Features/Application List/ApplicationListItem.swift
@@ -45,33 +45,33 @@ class ApplicationListItem: CollectionViewItem, CollectionViewItemComponent {
 
     stackView = HStack(iconView, verticalStackView, syncView)
     stackView.distribution = .fill
-    stackView.spacing = 8
+    stackView.spacing = 10
     stackView.edgeInsets = .init(top: 8, left: 8, bottom: 8, right: 8)
 
     titleLabel.isEditable = false
     titleLabel.drawsBackground = false
     titleLabel.isBezeled = false
-    titleLabel.font = NSFont.boldSystemFont(ofSize: 13)
+    titleLabel.font = NSFont.systemFont(ofSize: 13)
 
     subtitleLabel.isEditable = false
     subtitleLabel.drawsBackground = false
     subtitleLabel.isBezeled = false
     subtitleLabel.maximumNumberOfLines = 1
+    subtitleLabel.font = NSFont.systemFont(ofSize: 11)
+    subtitleLabel.alphaValue = 0.4
 
     view.addSubview(stackView)
     stackView.wantsLayer = true
-    stackView.layer?.cornerRadius = 4
 
     layoutConstraints = [
-      stackView.topAnchor.constraint(equalTo: view.topAnchor),
+      stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
       stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
       stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
       verticalStackView.heightAnchor.constraint(equalTo: stackView.heightAnchor),
       iconView.widthAnchor.constraint(equalToConstant: 32),
       iconView.heightAnchor.constraint(equalToConstant: 32),
-      syncView.widthAnchor.constraint(equalToConstant: 32),
-      syncView.heightAnchor.constraint(equalToConstant: 32)
+      syncView.widthAnchor.constraint(equalToConstant: 28),
+      syncView.heightAnchor.constraint(equalToConstant: 28)
     ]
     NSLayoutConstraint.constrain(layoutConstraints)
     updateState()
@@ -88,13 +88,13 @@ class ApplicationListItem: CollectionViewItem, CollectionViewItemComponent {
     if isSelected {
       stackView.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.3).cgColor
       syncView.contentTintColor = NSColor.controlAccentColor
-      titleLabel.textColor = NSColor.controlAccentColor.blended(withFraction: 0.75, of: .textColor)
-      subtitleLabel.textColor = NSColor.controlAccentColor.blended(withFraction: 0.4, of: .textColor)
+      titleLabel.textColor = NSColor.selectedTextColor
+      subtitleLabel.textColor = NSColor.selectedTextColor
     } else {
       stackView.layer?.backgroundColor = NSColor.clear.cgColor
       syncView.contentTintColor = NSColor.controlAccentColor
       titleLabel.textColor = NSColor.textColor
-      subtitleLabel.textColor = NSColor.textColor.blended(withFraction: 0.4, of: .white)
+      subtitleLabel.textColor = NSColor.textColor
     }
   }
 }

--- a/Sources/Features/Application List/ListContainerViewController.swift
+++ b/Sources/Features/Application List/ListContainerViewController.swift
@@ -5,6 +5,7 @@ class ListContainerViewController: FamilyViewController {
   let listViewController: ApplicationListItemViewController
   let searchViewController: ListSearchViewController
   let sortViewController: ListSortViewController
+  let visualEffect = NSVisualEffectView()
 
   init(listViewController: ApplicationListItemViewController,
        searchViewController: ListSearchViewController,
@@ -23,7 +24,12 @@ class ListContainerViewController: FamilyViewController {
 
   override func loadView() {
     super.loadView()
-    view = OpaqueView()
+
+    visualEffect.blendingMode = .behindWindow
+    visualEffect.state = .followsWindowActiveState
+    visualEffect.material = .sidebar
+
+    view = visualEffect
     view.autoresizingMask = [.width]
     view.autoresizesSubviews = true
   }
@@ -37,7 +43,6 @@ class ListContainerViewController: FamilyViewController {
       add(sortViewController)
         .padding(.init(top: 10, left: 10, bottom: 0, right: 10))
       add(listViewController, view: { $0.collectionView })
-        .margin(.init(top: 0, left: 10, bottom: 10, right: 10))
     }
   }
 }

--- a/Sources/Features/Application List/ListFeatureViewController.swift
+++ b/Sources/Features/Application List/ListFeatureViewController.swift
@@ -13,13 +13,14 @@ class ListFeatureViewController: NSViewController,
 
   weak var delegate: ListFeatureViewControllerDelegate?
 
-  lazy var titlebarView = NSView()
+  let titlebarView: NSView
   lazy var titleLabel = SmallLabel()
 
   let iconController: IconController
   let syncController: SyncController
   let machineController: MachineController
   let containerViewController: ListContainerViewController
+  let titlebarVisualEffectView = NSVisualEffectView()
 
   var applications = [Application]()
   var sort: ListSortViewController.SortKind = UserDefaults.standard.listSort ?? .name
@@ -34,6 +35,10 @@ class ListFeatureViewController: NSViewController,
     self.iconController = iconController
     self.machineController = machineController
     self.syncController = syncController
+    self.titlebarVisualEffectView.blendingMode = .withinWindow
+    self.titlebarVisualEffectView.state = .followsWindowActiveState
+    self.titlebarVisualEffectView.material = .titlebar
+    self.titlebarView = titlebarVisualEffectView
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -53,20 +58,20 @@ class ListFeatureViewController: NSViewController,
                                            object: nil)
   }
 
+  // MARK: - View life cycle
+
   override func viewDidLoad() {
     super.viewDidLoad()
-    title = Bundle.main.infoDictionary?["CFBundleName"] as? String
+//    title =
 
     NSLayoutConstraint.deactivate(layoutConstraints)
     layoutConstraints = []
 
     titleLabel.alignment = .center
-    titleLabel.stringValue = title!
     titleLabel.translatesAutoresizingMaskIntoConstraints = false
 
     titlebarView.subviews.forEach { $0.removeFromSuperview() }
     titlebarView.wantsLayer = true
-    titlebarView.layer?.backgroundColor =  NSColor.windowBackgroundColor.cgColor
     titlebarView.addSubview(titleLabel)
 
     layoutConstraints.append(contentsOf: [
@@ -80,6 +85,16 @@ class ListFeatureViewController: NSViewController,
     containerViewController.listViewController.collectionView.backgroundColors = [NSColor.clear]
     containerViewController.searchViewController.delegate = self
     containerViewController.sortViewController.delegate = self
+  }
+
+  override func viewWillLayout() {
+    super.viewWillLayout()
+    if view.window?.effectiveAppearance.name == .aqua {
+      view.layer?.backgroundColor = NSColor.white.cgColor
+      containerViewController.visualEffect.material = .underWindowBackground
+    } else {
+      view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+    }
   }
 
   @objc func mainWindowDidResignKey() { containerViewController.listViewController.collectionView.alphaValue = 0.8 }

--- a/Sources/Features/Detail/DetailContainerViewController.swift
+++ b/Sources/Features/Detail/DetailContainerViewController.swift
@@ -26,7 +26,12 @@ class DetailContainerViewController: FamilyViewController {
 
   override func loadView() {
     super.loadView()
-    view = OpaqueView()
+    let visualEffect = NSVisualEffectView()
+    visualEffect.blendingMode = .behindWindow
+    visualEffect.state = .followsWindowActiveState
+    visualEffect.material = .contentBackground
+
+    view = visualEffect
     view.autoresizingMask = [.width]
     view.autoresizesSubviews = true
   }

--- a/Sources/Features/Detail/DetailFeatureViewController.swift
+++ b/Sources/Features/Detail/DetailFeatureViewController.swift
@@ -11,7 +11,7 @@ class DetailFeatureViewController: NSViewController,
   }
 
   lazy var titleLabel = SmallLabel()
-  lazy var titlebarView = NSView()
+  let titlebarView: NSView
 
   private var layoutConstraints = [NSLayoutConstraint]()
   private(set) var modified: Bool = false
@@ -22,6 +22,7 @@ class DetailFeatureViewController: NSViewController,
   let iconController: IconController
   let syncController: SyncController
   let machineController: MachineController
+  let titlebarVisualEffectView = NSVisualEffectView()
 
   var machines = [Machine]()
   var application: Application?
@@ -38,6 +39,10 @@ class DetailFeatureViewController: NSViewController,
     self.iconController = iconController
     self.machineController = machineController
     self.syncController = syncController
+    self.titlebarVisualEffectView.blendingMode = .withinWindow
+    self.titlebarVisualEffectView.material = .titlebar
+    self.titlebarVisualEffectView.state = .followsWindowActiveState
+    self.titlebarView = titlebarVisualEffectView
     super.init(nibName: nil, bundle: nil)
   }
 
@@ -53,10 +58,12 @@ class DetailFeatureViewController: NSViewController,
   override func viewWillLayout() {
     super.viewWillLayout()
 
-    if view.effectiveAppearance.name == .aqua {
+    if view.window?.effectiveAppearance.name == .aqua {
       view.layer?.backgroundColor = NSColor.white.cgColor
+      titlebarVisualEffectView.state = .followsWindowActiveState
     } else {
       view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+      titlebarVisualEffectView.state = .followsWindowActiveState
     }
   }
 
@@ -81,7 +88,8 @@ class DetailFeatureViewController: NSViewController,
       containerViewController.generalActionsViewController.view.isHidden = true
     case .single(let application):
       let version = (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0.0.0"
-      titleLabel.stringValue = "\(version)-alpha"
+      let appName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
+      titleLabel.stringValue = "\(appName) \(version)-alpha"
       containerViewController.applicationDetailViewController.reload(with: [])
       containerViewController.generalInfoViewController.render(application,
                                                                iconController: iconController,
@@ -99,14 +107,8 @@ class DetailFeatureViewController: NSViewController,
 
     titlebarView.addSubview(titleLabel)
 
-    let issueButton = Button(title: "Feedback",
-                             font: .boldSystemFont(ofSize: 12),
-                             backgroundColor: .clear,
-                             borderColor: NSColor.systemGreen.blended(withFraction: 0.5, of: NSColor.white)!,
-                             borderWidth: 1,
-                             cornerRadius: .custom(4),
-                             target: self,
-                             action: #selector(newIssue))
+    let issueButton = NSButton(title: "Feedback", target: self, action: #selector(newIssue))
+    issueButton.font = .systemFont(ofSize: 12)
 
     let hStack = HStack(issueButton)
 

--- a/Sources/Views/BackgroundView.swift
+++ b/Sources/Views/BackgroundView.swift
@@ -1,5 +1,6 @@
 import Cocoa
 
 class BackgroundView: LayeredView, DecorationView {
+  override var isOpaque: Bool { return false }
   weak var belongsToView: NSView?
 }

--- a/Sources/Views/SearchField.swift
+++ b/Sources/Views/SearchField.swift
@@ -4,7 +4,7 @@ class SearchField: NSSearchField {
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
     wantsLayer = true
-    font = NSFont.systemFont(ofSize: 14)
+    font = NSFont.systemFont(ofSize: 13)
   }
 
   required init?(coder: NSCoder) {
@@ -16,9 +16,9 @@ class SearchField: NSSearchField {
     if currentEditor() != nil {
       layer?.borderColor = NSColor.controlAccentColor.cgColor
     } else {
-      layer?.borderColor = NSColor.windowFrameColor.cgColor
+      layer?.borderColor = NSColor.windowFrameTextColor.withAlphaComponent(0.1).cgColor
     }
-    layer?.cornerRadius = frame.size.height / 2
+    layer?.cornerRadius = 4
     layer?.borderWidth = 1
   }
 }

--- a/Sources/Views/SplitView.swift
+++ b/Sources/Views/SplitView.swift
@@ -1,0 +1,15 @@
+import Cocoa
+
+class SplitView: NSSplitView {
+  override var dividerThickness: CGFloat { return 0.0 }
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+    dividerStyle = .thin
+    isVertical = true
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/Syncalicious.xcodeproj/project.pbxproj
+++ b/Syncalicious.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		BDB919642259F7020096294D /* BackupControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB919632259F7020096294D /* BackupControllerTests.swift */; };
 		BDCBB2AB22551372007C9404 /* ApplicationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCBB2AA22551372007C9404 /* ApplicationControllerTests.swift */; };
 		BDCBB2C022551C5B007C9404 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BDCBB2C222551C5B007C9404 /* Localizable.strings */; };
+		BDD3DF6A2323B9D00059A2B1 /* SplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD3DF692323B9D00059A2B1 /* SplitView.swift */; };
 		BDDAA333225D37BD00D87664 /* LayeredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA332225D37BD00D87664 /* LayeredView.swift */; };
 		BDDAA335225D37C700D87664 /* DecorationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA334225D37C700D87664 /* DecorationView.swift */; };
 		BDDAA337225D37D100D87664 /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDAA336225D37D100D87664 /* BackgroundView.swift */; };
@@ -194,6 +195,7 @@
 		BDCBB2AC22551372007C9404 /* Info-Tests.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Tests.plist"; sourceTree = "<group>"; };
 		BDCBB2B622551725007C9404 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		BDCBB2C122551C5B007C9404 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		BDD3DF692323B9D00059A2B1 /* SplitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitView.swift; sourceTree = "<group>"; };
 		BDDAA332225D37BD00D87664 /* LayeredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayeredView.swift; sourceTree = "<group>"; };
 		BDDAA334225D37C700D87664 /* DecorationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecorationView.swift; sourceTree = "<group>"; };
 		BDDAA336225D37D100D87664 /* BackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 				BDFF6FDC231ED91F00F53B71 /* StackView.swift */,
 				BDFF6FD6231ED8E300F53B71 /* TextField.swift */,
 				BDFF6FE0231ED94300F53B71 /* VStack.swift */,
+				BDD3DF692323B9D00059A2B1 /* SplitView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -770,6 +773,7 @@
 				BDA1C3D72271A8A6009185DE /* ComputerDetailItem.swift in Sources */,
 				BDFF6FE1231ED94300F53B71 /* VStack.swift in Sources */,
 				BDE9E63622704AFD00C28F34 /* AnimationFactory.swift in Sources */,
+				BDD3DF6A2323B9D00059A2B1 /* SplitView.swift in Sources */,
 				BD8EDD822255CE3400110E56 /* IconController.swift in Sources */,
 				BDDAA34F225E52DA00D87664 /* DetailContainerViewController.swift in Sources */,
 				BD3CC250225B147F006D7877 /* SplitViewController.swift in Sources */,


### PR DESCRIPTION
## Description

- The list items now have less height to fit more applications on screen, this results in less scrolling when using the application
- The search field is now styled after the upcoming macOS Catalina release, this is mostly done by reducing the amount of corner radius that the view gets
- The application now supports both light and dark appearance
- The side menu (the application list) now uses a `NSVisualEffectView`
- The feedback button now uses a regular `NSButton`

## Screenshots

### Dark mode
<img width="912" alt="Screen Shot 2019-09-08 at 20 16 42" src="https://user-images.githubusercontent.com/57446/64492580-9ab3ec00-d275-11e9-8acc-0abdc153929d.png">

### Light mode
<img width="912" alt="Screen Shot 2019-09-08 at 20 16 28" src="https://user-images.githubusercontent.com/57446/64492581-9ab3ec00-d275-11e9-820e-55208b8feca6.png">