### PR TITLE
Set activation policy to .accessory on launch

### DIFF
--- a/Sources/Application/AppDelegateController.swift
+++ b/Sources/Application/AppDelegateController.swift
@@ -100,6 +100,9 @@ class ApplicationDelegateController: ApplicationControllerDelegate,
       if let previousFrame = previousFrame {
         windowController.window?.setFrame(previousFrame, display: true)
       }
+      #else
+      NSApp.dockTile.badgeLabel = nil
+      NSApp.setActivationPolicy(.accessory)
       #endif
 
       delegate?.applicationDelegateController(self, didLoadApplication: true)


### PR DESCRIPTION
- Hides the application icon after launch